### PR TITLE
updated script args for server settings

### DIFF
--- a/docs/atacr.rst
+++ b/docs/atacr.rst
@@ -594,21 +594,10 @@ Usage
     Server Settings:
       Settings associated with which datacenter to log into.
 
-      --server-cat SERVER_CAT
-                            Catalogue server setting: Key string for recognized
-                            server that provide `available_event_catalogs` service
-                            (one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA',
-                            'EMSC', 'ETH', 'GEOFON', 'GEONET', 'GFZ', 'ICGC',
-                            'IESDMC', 'INGV', 'IPGP', 'IRIS', 'IRISPH5', 'ISC',
-                            'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA',
-                            'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF',
-                            'RESIFPH5', 'SCEDC', 'TEXNET', 'UIB-NORSAR', 'USGS',
-                            'USP'). [Default 'IRIS']
-      --server-wf SERVER_WF
-                            Waveform server setting: Base URL of FDSN web service
-                            compatible server (e.g. “http://service.iris.edu”) or
-                            key string for recognized server (one of 'AUSPASS',
-                            'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', 'GEOFON',
+      --server SERVER       Base URL of FDSN web service compatible server (e.g.
+                            “http://service.iris.edu”) or key string for
+                            recognized server (one of 'AUSPASS', 'BGR',
+                            'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', 'GEOFON',
                             'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP',
                             'IRIS', 'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU',
                             'NCEDC', 'NIEP', 'NOA', 'NRCAN', 'ODC', 'ORFEUS',

--- a/docs/atacr.rst
+++ b/docs/atacr.rst
@@ -251,20 +251,28 @@ Usage
     Server Settings:
       Settings associated with which datacenter to log into.
 
-      -S SERVER, --server SERVER
-                            Specify the server to connect to. Options include:
-                            BGR, ETH, GEONET, GFZ, INGV, IPGP, IRIS, KOERI, LMU,
-                            NCEDC, NEIP, NERIES, ODC, ORFEUS, RESIF, SCEDC, USGS,
-                            USP. [Default IRIS]
-      --server-url SERVER_URL
-                            Specify the obspy base_url server address (and port if
-                            needed) to open for the fdsn client. Overrides any
-                            settings to '--server'. [Default None]
-      -U USERAUTH, --user-auth USERAUTH
-                            Enter your Authentification Username and Password
-                            (--user-auth='username:authpassword') to access and
-                            download restricted data. [Default no user and
-                            password]
+      --server SERVER       Base URL of FDSN web service compatible server (e.g.
+                            “http://service.iris.edu”) or key string for
+                            recognized server (one of 'AUSPASS', 'BGR',
+                            'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', 'GEOFON',
+                            'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP',
+                            'IRIS', 'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU',
+                            'NCEDC', 'NIEP', 'NOA', 'NRCAN', 'ODC', 'ORFEUS',
+                            'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', 'TEXNET',
+                            'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']
+      --user-auth USERAUTH  Authentification Username and Password for the
+                            waveform server (--user-auth='username:authpassword')
+                            to access and download restricted data. [Default no
+                            user and password]
+      --eida-token TOKENFILE
+                            Token for EIDA authentication mechanism, see
+                            http://geofon.gfz-
+                            potsdam.de/waveform/archive/auth/index.php. If a token
+                            is provided, argument --user-auth will be ignored.
+                            This mechanism is only available on select EIDA nodes.
+                            The token can be provided in form of the PGP message
+                            as a string, or the filename of a local file with the
+                            PGP message in it. [Default None]
 
     Frequency Settings:
       Miscellaneous frequency settings
@@ -586,21 +594,40 @@ Usage
     Server Settings:
       Settings associated with which datacenter to log into.
 
-      -S SERVER, --server SERVER
-                            Specify the server to connect to. Options include:
-                            BGR, ETH, GEONET, GFZ, INGV, IPGP, IRIS, KOERI, LMU,
-                            NCEDC, NEIP, NERIES, ODC, ORFEUS, RESIF, SCEDC, USGS,
-                            USP. [Default IRIS]
-      --server-url SERVER_URL
-                            Specify the obspy base_url server address (and port if
-                            needed) to open for the fdsn client. Overrides any
-                            settings to '--server'. [Default None]
-      -U USERAUTH, --user-auth USERAUTH
-                            Enter your Authentification Username and Password
-                            (--user-auth='username:authpassword') to access and
-                            download restricted data. [Default no user and
-                            password]
-
+      --server-cat SERVER_CAT
+                            Catalogue server setting: Key string for recognized
+                            server that provide `available_event_catalogs` service
+                            (one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA',
+                            'EMSC', 'ETH', 'GEOFON', 'GEONET', 'GFZ', 'ICGC',
+                            'IESDMC', 'INGV', 'IPGP', 'IRIS', 'IRISPH5', 'ISC',
+                            'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA',
+                            'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF',
+                            'RESIFPH5', 'SCEDC', 'TEXNET', 'UIB-NORSAR', 'USGS',
+                            'USP'). [Default 'IRIS']
+      --server-wf SERVER_WF
+                            Waveform server setting: Base URL of FDSN web service
+                            compatible server (e.g. “http://service.iris.edu”) or
+                            key string for recognized server (one of 'AUSPASS',
+                            'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', 'GEOFON',
+                            'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP',
+                            'IRIS', 'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU',
+                            'NCEDC', 'NIEP', 'NOA', 'NRCAN', 'ODC', 'ORFEUS',
+                            'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', 'TEXNET',
+                            'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']
+      --user-auth USERAUTH  Authentification Username and Password for the
+                            waveform server (--user-auth='username:authpassword')
+                            to access and download restricted data. [Default no
+                            user and password]
+      --eida-token TOKENFILE
+                            Token for EIDA authentication mechanism, see
+                            http://geofon.gfz-
+                            potsdam.de/waveform/archive/auth/index.php. If a token
+                            is provided, argument --user-auth will be ignored.
+                            This mechanism is only available on select EIDA nodes.
+                            The token can be provided in form of the PGP message
+                            as a string, or the filename of a local file with the
+                            PGP message in it. [Default None]
+                            
     Frequency Settings:
       Miscellaneous frequency settings
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ can be used through command-line scripts.
 .. image:: https://github.com/nfsi-canada/OBStools/workflows/Build/badge.svg
    :target: https://github.com/nfsi-canada/OBStools/actions
 .. image:: https://codecov.io/gh/nfsi-canada/OBStools/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/nfsi-canada/OBStools
+   :target: https://codecov.io/gh/nfsi-canada/OBStools
 
 .. toctree::
    :maxdepth: 1

--- a/obstools/scripts/atacr_download_data.py
+++ b/obstools/scripts/atacr_download_data.py
@@ -350,16 +350,11 @@ def main(args=None):
             datapath.mkdir(parents=True)
 
         # Establish client
-        if args.verb > 1:
-            print("   Establishing Client...")
         client = Client(
             base_url=args.server,
             user=args.userauth[0],
             password=args.userauth[1],
             eida_token=args.tokenfile)
-        if args.verb > 1:
-            print("      Done")
-            print(" ")
 
         # Get catalogue search start time
         if args.startT is None:

--- a/obstools/scripts/atacr_download_data.py
+++ b/obstools/scripts/atacr_download_data.py
@@ -109,33 +109,39 @@ def get_daylong_arguments(argv=None):
         description="Settings associated with which "
         "datacenter to log into.")
     ServerGroup.add_argument(
-        "-S", "--server",
+        "--server",
         action="store",
         type=str,
         dest="server",
         default="IRIS",
-        help="Specify the server to connect to. Options include: " +
-        "BGR, ETH, GEONET, GFZ, INGV, IPGP, IRIS, KOERI, LMU, NCEDC, " +
-        "NEIP, NERIES, ODC, ORFEUS, RESIF, SCEDC, USGS, USP. " +
-        "[Default IRIS]")
+        help="Base URL of FDSN web service compatible "
+        "server (e.g. “http://service.iris.edu”) or key string for recognized "
+        "server (one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', "
+        "'GEOFON', 'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP', 'IRIS', "
+        "'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA', "
+        "'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', "
+        "'TEXNET', 'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']")
     ServerGroup.add_argument(
-        "--server-url",
-        action="store",
-        type=str,
-        dest="server_url",
-        default=None,
-        help="Specify the obspy base_url server address (and port if needed) " +
-         "to open for the fdsn client. Overrides any settings to '--server'. " +
-         "[Default None]")
-    ServerGroup.add_argument(
-        "-U", "--user-auth",
+        "--user-auth",
         action="store",
         type=str,
         dest="userauth",
-        default="",
-        help="Enter your Authentification Username and Password " +
-        "(--user-auth='username:authpassword') to access and download " +
-        "restricted data. [Default no user and password]")
+        default=None,
+        help="Authentification Username and Password for the " +
+        "waveform server (--user-auth='username:authpassword') to access " +
+        "and download restricted data. [Default no user and password]")
+    ServerGroup.add_argument(
+        "--eida-token", 
+        action="store", 
+        type=str,
+        dest="tokenfile", 
+        default=None, 
+        help="Token for EIDA authentication mechanism, see " +
+        "http://geofon.gfz-potsdam.de/waveform/archive/auth/index.php. "
+        "If a token is provided, argument --user-auth will be ignored. "
+        "This mechanism is only available on select EIDA nodes. The token can "
+        "be provided in form of the PGP message as a string, or the filename of "
+        "a local file with the PGP message in it. [Default None]")
 
     """
     # Database Settings
@@ -258,17 +264,20 @@ def get_daylong_arguments(argv=None):
     else:
         args.endT = None
 
-    # Parse User Authentification
-    if not len(args.userauth) == 0:
-        tt = args.userauth.split(':')
-        if not len(tt) == 2:
-            parser.error(
-                "Error: Incorrect Username and Password Strings for " +
-                "User Authentification")
-        else:
-            args.userauth = tt
+    # Parse restricted data settings
+    if args.tokenfile is not None:
+        args.userauth = [None, None]
     else:
-        args.userauth = []
+        if args.userauth is not None:
+            tt = args.userauth.split(':')
+            if not len(tt) == 2:
+                msg = ("Error: Incorrect Username and Password Strings for User "
+                       "Authentification")
+                parser.error(msg)
+            else:
+                args.userauth = tt
+        else:
+            args.userauth = [None, None]
 
     # # Parse Local Data directories
     # if args.localdata is not None:
@@ -283,17 +292,19 @@ def get_daylong_arguments(argv=None):
     #     args.ndval = nan
 
     if args.units not in ['DISP', 'VEL', 'ACC']:
-        raise(Exception(
-            "Error: invalid --units argument. Choose among " +
-            "'DISP', 'VEL', or 'ACC'"))
+        msg = ("Error: invalid --units argument. Choose among "
+            "'DISP', 'VEL', or 'ACC'")
+        parser.error(msg)
+
     if args.pre_filt is None:
         args.pre_filt = [0.001, 0.005, 45., 50.]
     else:
         args.pre_filt = [float(val) for val in args.pre_filt.split(',')]
         args.pre_filt = sorted(args.pre_filt)
         if (len(args.pre_filt)) != 4:
-            raise(Exception(
-                "Error: --pre-filt should contain 4 comma-separated floats"))
+            msg = ("Error: --pre-filt should contain 4 "
+                "comma-separated floats")
+            parser.error(msg)
 
     return args
 
@@ -339,24 +350,16 @@ def main(args=None):
             datapath.mkdir(parents=True)
 
         # Establish client
-        if len(args.userauth) == 0:
-            if args.server_url is not None:
-                client = Client(
-                    base_url=args.server_url)
-            else:
-                client = Client(
-                    args.server)
-        else:
-            if args.server_url is not None:
-                client = Client(
-                    base_url=args.server_url,
-                    user=args.userauth[0], 
-                    password=args.userauth[1])
-            else:
-                client = Client(
-                    args.server, 
-                    user=args.userauth[0], 
-                    password=args.userauth[1])
+        if args.verb > 1:
+            print("   Establishing Client...")
+        client = Client(
+            base_url=args.server,
+            user=args.userauth[0],
+            password=args.userauth[1],
+            eida_token=args.tokenfile)
+        if args.verb > 1:
+            print("      Done")
+            print(" ")
 
         # Get catalogue search start time
         if args.startT is None:

--- a/obstools/scripts/atacr_download_event.py
+++ b/obstools/scripts/atacr_download_event.py
@@ -112,33 +112,52 @@ def get_event_arguments(argv=None):
         description="Settings associated with which "
         "datacenter to log into.")
     ServerGroup.add_argument(
-        "-S", "--server",
+        "--server-cat",
         action="store",
         type=str,
-        dest="server",
+        dest="server_cat",
         default="IRIS",
-        help="Specify the server to connect to. Options include: " +
-        "BGR, ETH, GEONET, GFZ, INGV, IPGP, IRIS, KOERI, LMU, NCEDC, " +
-        "NEIP, NERIES, ODC, ORFEUS, RESIF, SCEDC, USGS, USP. " +
-        "[Default IRIS]")
+        help="Catalogue server setting: Key string for recognized server that "
+            "provide `available_event_catalogs` service "
+            "(one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', "
+            "'GEOFON', 'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP', 'IRIS', "
+            "'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA', "
+            "'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', "
+            "'TEXNET', 'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']")
     ServerGroup.add_argument(
-        "--server-url",
+        "--server-wf",
         action="store",
         type=str,
-        dest="server_url",
-        default=None,
-        help="Specify the obspy base_url server address (and port if needed) " +
-         "to open for the fdsn client. Overrides any settings to '--server'. " +
-         "[Default None]")
+        dest="server_wf",
+        default="IRIS",
+        help="Waveform server setting: Base URL of FDSN web service compatible "
+            "server (e.g. “http://service.iris.edu”) or key string for recognized "
+            "server (one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', "
+            "'GEOFON', 'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP', 'IRIS', "
+            "'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA', "
+            "'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', "
+            "'TEXNET', 'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']")
     ServerGroup.add_argument(
-        "-U", "--user-auth",
+        "--user-auth",
         action="store",
         type=str,
         dest="userauth",
-        default="",
-        help="Enter your Authentification Username and Password " +
-        "(--user-auth='username:authpassword') to access and download " +
-        "restricted data. [Default no user and password]")
+        default=None,
+        help="Authentification Username and Password for the " +
+            "waveform server (--user-auth='username:authpassword') to access " +
+            "and download restricted data. [Default no user and password]")
+    ServerGroup.add_argument(
+        "--eida-token", 
+        action="store", 
+        type=str,
+        dest="tokenfile", 
+        default=None, 
+        help="Token for EIDA authentication mechanism, see " +
+            "http://geofon.gfz-potsdam.de/waveform/archive/auth/index.php. "
+            "If a token is provided, argument --user-auth will be ignored. "
+            "This mechanism is only available on select EIDA nodes. The token can "
+            "be provided in form of the PGP message as a string, or the filename of "
+            "a local file with the PGP message in it. [Default None]")
 
     # Constants Settings
     FreqGroup = parser.add_argument_group(
@@ -301,17 +320,25 @@ def get_event_arguments(argv=None):
     else:
         args.endT = None
 
-    # Parse User Authentification
-    if not len(args.userauth) == 0:
-        tt = args.userauth.split(':')
-        if not len(tt) == 2:
-            parser.error(
-                "Error: Incorrect Username and Password Strings for User " +
-                "Authentification")
-        else:
-            args.userauth = tt
+    # Parse restricted data settings
+    if args.tokenfile is not None:
+        args.userauth = [None, None]
     else:
-        args.userauth = []
+        if args.userauth is not None:
+            tt = args.userauth.split(':')
+            if not len(tt) == 2:
+                msg = ("Error: Incorrect Username and Password Strings for User "
+                       "Authentification")
+                parser.error(msg)
+            else:
+                args.userauth = tt
+        else:
+            args.userauth = [None, None]
+
+    if args.units not in ['DISP', 'VEL', 'ACC']:
+        msg = ("Error: invalid --units argument. Choose among "
+            "'DISP', 'VEL', or 'ACC'")
+        parser.error(msg)
 
     if args.pre_filt is None:
         args.pre_filt = [0.001, 0.005, 45., 50.]
@@ -319,9 +346,9 @@ def get_event_arguments(argv=None):
         args.pre_filt = [float(val) for val in args.pre_filt.split(',')]
         args.pre_filt = sorted(args.pre_filt)
         if (len(args.pre_filt)) != 4:
-            raise(Exception(
-                "Error: --pre-filt should contain 4 " +
-                "comma-separated floats"))
+            msg = ("Error: --pre-filt should contain 4 "
+                "comma-separated floats")
+            parser.error(msg)
 
     return args
 
@@ -366,25 +393,16 @@ def main(args=None):
             print('\nPath to '+str(eventpath)+' doesn`t exist - creating it')
             eventpath.mkdir(parents=True)
 
-        # Establish client
-        if len(args.userauth) == 0:
-            if args.server_url is not None:
-                client = Client(
-                    base_url=args.server_url)
-            else:
-                client = Client(
-                    args.server)
-        else:
-            if args.server_url is not None:
-                client = Client(
-                    base_url=args.server_url,
-                    user=args.userauth[0], 
-                    password=args.userauth[1])
-            else:
-                client = Client(
-                    args.server, 
-                    user=args.userauth[0], 
-                    password=args.userauth[1])
+        # Establish client for catalogue
+        cat_client = Client(
+            base_url=args.server_cat)
+
+        # Establish client for waveforms
+        wf_client = Client(
+            base_url=args.server_wf,
+            user=args.userauth[0],
+            password=args.userauth[1],
+            eida_token=args.tokenfile)
 
         # Get catalogue search start time
         if args.startT is None:

--- a/obstools/scripts/atacr_download_event.py
+++ b/obstools/scripts/atacr_download_event.py
@@ -112,31 +112,18 @@ def get_event_arguments(argv=None):
         description="Settings associated with which "
         "datacenter to log into.")
     ServerGroup.add_argument(
-        "--server-cat",
+        "--server",
         action="store",
         type=str,
-        dest="server_cat",
+        dest="server",
         default="IRIS",
-        help="Catalogue server setting: Key string for recognized server that "
-            "provide `available_event_catalogs` service "
-            "(one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', "
-            "'GEOFON', 'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP', 'IRIS', "
-            "'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA', "
-            "'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', "
-            "'TEXNET', 'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']")
-    ServerGroup.add_argument(
-        "--server-wf",
-        action="store",
-        type=str,
-        dest="server_wf",
-        default="IRIS",
-        help="Waveform server setting: Base URL of FDSN web service compatible "
-            "server (e.g. “http://service.iris.edu”) or key string for recognized "
-            "server (one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', "
-            "'GEOFON', 'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP', 'IRIS', "
-            "'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA', "
-            "'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', "
-            "'TEXNET', 'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']")
+        help="Base URL of FDSN web service compatible "
+        "server (e.g. “http://service.iris.edu”) or key string for recognized "
+        "server (one of 'AUSPASS', 'BGR', 'EARTHSCOPE', 'EIDA', 'EMSC', 'ETH', "
+        "'GEOFON', 'GEONET', 'GFZ', 'ICGC', 'IESDMC', 'INGV', 'IPGP', 'IRIS', "
+        "'IRISPH5', 'ISC', 'KNMI', 'KOERI', 'LMU', 'NCEDC', 'NIEP', 'NOA', "
+        "'NRCAN', 'ODC', 'ORFEUS', 'RASPISHAKE', 'RESIF', 'RESIFPH5', 'SCEDC', "
+        "'TEXNET', 'UIB-NORSAR', 'USGS', 'USP'). [Default 'IRIS']")
     ServerGroup.add_argument(
         "--user-auth",
         action="store",
@@ -393,16 +380,15 @@ def main(args=None):
             print('\nPath to '+str(eventpath)+' doesn`t exist - creating it')
             eventpath.mkdir(parents=True)
 
-        # Establish client for catalogue
-        cat_client = Client(
-            base_url=args.server_cat)
-
-        # Establish client for waveforms
-        wf_client = Client(
-            base_url=args.server_wf,
+        # Establish client
+        client = Client(
+            base_url=args.server,
             user=args.userauth[0],
             password=args.userauth[1],
             eida_token=args.tokenfile)
+
+        # Establish client for events - Default is 'IRIS''
+        event_client = Client()
 
         # Get catalogue search start time
         if args.startT is None:
@@ -460,7 +446,7 @@ def main(args=None):
         print("| ...                                           |")
 
         # Get catalogue using deployment start and end
-        cat = client.get_events(
+        cat = event_client.get_events(
             starttime=tstart, endtime=tend,
             minmagnitude=args.minmag, maxmagnitude=args.maxmag)
 


### PR DESCRIPTION
PR to update server settings in scripts

- allows a single `--server` argument used as `base_url` kwarg in `Client()`
- includes a new `--eida-token` argument for restricted access to server with token Authentification
- updated docs